### PR TITLE
introduce debian bookworm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,14 +12,16 @@ jobs:
       fail-fast: false
       matrix:
         distribution:
-          - alpine3.11
-          - alpine3.12
-          - alpine3.13
-          - alpine3.14
-          - buster
-          - slim-buster
+          - bookworm
+          - slim-bookworm
           - bullseye
           - slim-bullseye
+          - buster
+          - slim-buster
+          - alpine3.14
+          - alpine3.13
+          - alpine3.12
+          - alpine3.11
         dictionary:
           - ipadic
           - jumandic

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Only UTF-8 encoded dictionaries are supported.
 
 ## Available Tags
 
+- ipadic-bookworm
+- ipadic-slim-bookworm
 - ipadic-bullseye
 - ipadic-slim-bullseye
 - ipadic-buster
@@ -25,6 +27,8 @@ Only UTF-8 encoded dictionaries are supported.
 - ipadic-alpine3.13
 - ipadic-alpine3.12
 - ipadic-alpine3.11
+- jumandic-bookworm
+- jumandic-slim-bookworm
 - jumandic-bullseye
 - jumandic-slim-bullseye
 - jumandic-buster
@@ -41,6 +45,7 @@ Dockerfiles are available under [the MIT License](https://github.com/shogo82148/
 These images contain MeCab, ipadic, and jumandic.
 The license information can be found in [CREDITS](https://github.com/shogo82148/mecab-docker/blob/main/CREDITS).
 
+UsageText: |
 # Usage
 
 The images are available on DockerHub, GitHub Packages Container registry, and Amazon ECR Public Gallery.
@@ -52,7 +57,7 @@ The images are available on DockerHub, GitHub Packages Container registry, and A
 ## DockerHub
 
 ```
-$ docker run -it --rm shogo82148/mecab:ipadic-slim-buster
+$ docker run -it --rm shogo82148/mecab:ipadic-slim-bullseye
 すもももももももものうち
 すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
 も      助詞,係助詞,*,*,*,*,も,モ,モ
@@ -67,7 +72,7 @@ EOS
 ## GitHub Packages Container registry
 
 ```
-$ docker run -it --rm ghcr.io/shogo82148/mecab:ipadic-slim-buster
+$ docker run -it --rm ghcr.io/shogo82148/mecab:ipadic-slim-bullseye
 すもももももももものうち
 すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
 も      助詞,係助詞,*,*,*,*,も,モ,モ
@@ -82,7 +87,7 @@ EOS
 ## Amazon ECR Public Gallery
 
 ```
-$ docker run -it --rm public.ecr.aws/shogo82148/mecab:ipadic-slim-buster
+$ docker run -it --rm public.ecr.aws/shogo82148/mecab:ipadic-slim-bullseye
 すもももももももものうち
 すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
 も      助詞,係助詞,*,*,*,*,も,モ,モ

--- a/cloudformation/ecr.yml
+++ b/cloudformation/ecr.yml
@@ -32,16 +32,20 @@ Resources:
 
           ## Available Tags
 
-          - ipadic-billseye
-          - ipadic-slim-billseye
+          - ipadic-bookworm
+          - ipadic-slim-bookworm
+          - ipadic-bullseye
+          - ipadic-slim-bullseye
           - ipadic-buster
           - ipadic-slim-buster
           - ipadic-alpine3.14
           - ipadic-alpine3.13
           - ipadic-alpine3.12
           - ipadic-alpine3.11
-          - jumandic-billseye
-          - jumandic-slim-billseye
+          - jumandic-bookworm
+          - jumandic-slim-bookworm
+          - jumandic-bullseye
+          - jumandic-slim-bullseye
           - jumandic-buster
           - jumandic-slim-buster
           - jumandic-alpine3.14
@@ -68,7 +72,7 @@ Resources:
           ## DockerHub
 
           ```
-          $ docker run -it --rm shogo82148/mecab:ipadic-slim-buster
+          $ docker run -it --rm shogo82148/mecab:ipadic-slim-bullseye
           すもももももももものうち
           すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
           も      助詞,係助詞,*,*,*,*,も,モ,モ
@@ -83,7 +87,7 @@ Resources:
           ## GitHub Packages Container registry
 
           ```
-          $ docker run -it --rm ghcr.io/shogo82148/mecab:ipadic-slim-buster
+          $ docker run -it --rm ghcr.io/shogo82148/mecab:ipadic-slim-bullseye
           すもももももももものうち
           すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
           も      助詞,係助詞,*,*,*,*,も,モ,モ
@@ -98,7 +102,7 @@ Resources:
           ## Amazon ECR Public Gallery
 
           ```
-          $ docker run -it --rm public.ecr.aws/shogo82148/mecab:ipadic-slim-buster
+          $ docker run -it --rm public.ecr.aws/shogo82148/mecab:ipadic-slim-bullseye
           すもももももももものうち
           すもも  名詞,一般,*,*,*,*,すもも,スモモ,スモモ
           も      助詞,係助詞,*,*,*,*,も,モ,モ

--- a/ipadic/bookworm/Dockerfile
+++ b/ipadic/bookworm/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:bookworm
+
+# XXX: buildpack-deps:bookworm is not yet available.
+# FROM buildpack-deps:bookworm
+
+ENV MECAB_VERSION 0.996.6
+ENV IPADIC_VERSION 2.7.0-20070801
+
+# TODO: remove apt-get after buildpack-deps:bookworm is available.
+RUN set -eux; \
+    \
+    apt-get update && apt-get install -y --no-install-recommends \
+        tar wget g++ make ca-certificates \
+    && wget -O mecab.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-${MECAB_VERSION}.tar.gz" \
+    && wget -O mecab-ipadic.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-ipadic-${IPADIC_VERSION}.tar.gz" \
+    && mkdir -p /usr/src/mecab \
+    && tar -xzC /usr/src/mecab -f mecab.tar.gz \
+    && tar -xzC /usr/src/mecab -f mecab-ipadic.tar.gz \
+# build MeCab
+    && cd "/usr/src/mecab/mecab-${MECAB_VERSION}" \
+    && ./configure --enable-utf8-only \
+    && make -j$(nproc) && make install \
+    && ldconfig \
+# build the dictionary
+    && cd "/usr/src/mecab/mecab-ipadic-${IPADIC_VERSION}" \
+    && ./configure --with-charset=utf8 \
+    && make -j$(nproc) && make install \
+# clean up
+    && rm -rf /usr/src/mecab \
+    && apt-mark auto '.*' > /dev/null \
+    && find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
+        | awk '/=>/ { print $(NF-1) }' \
+        | sort -u \
+        | xargs -r dpkg-query --search \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -r apt-mark manual \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/* \
+    && mecab --version
+
+CMD /usr/local/bin/mecab

--- a/ipadic/slim-bookworm/Dockerfile
+++ b/ipadic/slim-bookworm/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:bookworm-slim
+
+ENV MECAB_VERSION 0.996.6
+ENV IPADIC_VERSION 2.7.0-20070801
+
+RUN set -eux; \
+    \
+    apt-get update && apt-get install -y --no-install-recommends \
+        tar wget g++ make ca-certificates \
+    && wget -O mecab.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-${MECAB_VERSION}.tar.gz" \
+    && wget -O mecab-ipadic.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-ipadic-${IPADIC_VERSION}.tar.gz" \
+    && mkdir -p /usr/src/mecab \
+    && tar -xzC /usr/src/mecab -f mecab.tar.gz \
+    && tar -xzC /usr/src/mecab -f mecab-ipadic.tar.gz \
+# build MeCab
+    && cd "/usr/src/mecab/mecab-${MECAB_VERSION}" \
+    && ./configure --enable-utf8-only \
+    && make -j$(nproc) && make install \
+    && ldconfig \
+# build the dictionary
+    && cd "/usr/src/mecab/mecab-ipadic-${IPADIC_VERSION}" \
+    && ./configure --with-charset=utf8 \
+    && make -j$(nproc) && make install \
+# clean up
+    && rm -rf /usr/src/mecab \
+    && apt-mark auto '.*' > /dev/null \
+    && find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
+        | awk '/=>/ { print $(NF-1) }' \
+        | sort -u \
+        | xargs -r dpkg-query --search \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -r apt-mark manual \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/* \
+    && mecab --version
+
+CMD /usr/local/bin/mecab

--- a/jumandic/bookworm/Dockerfile
+++ b/jumandic/bookworm/Dockerfile
@@ -1,0 +1,41 @@
+# XXX: buildpack-deps:bookworm is not yet available.
+# FROM buildpack-deps:bookworm
+FROM debian:bookworm
+
+ENV MECAB_VERSION 0.996.6
+ENV JUMANDIC_VERSION 7.0-20130310
+
+# TODO: remove apt-get after buildpack-deps:bookworm is available.
+RUN set -eux; \
+    \
+    apt-get update && apt-get install -y --no-install-recommends \
+        tar wget g++ make ca-certificates \
+    && wget -O mecab.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-${MECAB_VERSION}.tar.gz" \
+    && wget -O mecab-jumandic.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-jumandic-${JUMANDIC_VERSION}.tar.gz" \
+    && mkdir -p /usr/src/mecab \
+    && tar -xzC /usr/src/mecab -f mecab.tar.gz \
+    && tar -xzC /usr/src/mecab -f mecab-jumandic.tar.gz \
+# build MeCab
+    && cd "/usr/src/mecab/mecab-${MECAB_VERSION}" \
+    && ./configure --enable-utf8-only \
+    && make -j$(nproc) && make install \
+    && ldconfig \
+# build the dictionary
+    && cd "/usr/src/mecab/mecab-jumandic-${JUMANDIC_VERSION}" \
+    && ./configure --with-charset=utf8 \
+    && make -j$(nproc) && make install \
+# clean up
+    && rm -rf /usr/src/mecab \
+    && apt-mark auto '.*' > /dev/null \
+    && find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
+        | awk '/=>/ { print $(NF-1) }' \
+        | sort -u \
+        | xargs -r dpkg-query --search \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -r apt-mark manual \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/* \
+    && mecab --version
+
+CMD /usr/local/bin/mecab

--- a/jumandic/slim-bookworm/Dockerfile
+++ b/jumandic/slim-bookworm/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:bookworm-slim
+
+ENV MECAB_VERSION 0.996.6
+ENV JUMANDIC_VERSION 7.0-20130310
+
+RUN set -eux; \
+    \
+    apt-get update && apt-get install -y --no-install-recommends \
+        tar wget g++ make ca-certificates \
+    && wget -O mecab.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-${MECAB_VERSION}.tar.gz" \
+    && wget -O mecab-jumandic.tar.gz "https://github.com/shogo82148/mecab/releases/download/v${MECAB_VERSION}/mecab-jumandic-${JUMANDIC_VERSION}.tar.gz" \
+    && mkdir -p /usr/src/mecab \
+    && tar -xzC /usr/src/mecab -f mecab.tar.gz \
+    && tar -xzC /usr/src/mecab -f mecab-jumandic.tar.gz \
+# build MeCab
+    && cd "/usr/src/mecab/mecab-${MECAB_VERSION}" \
+    && ./configure --enable-utf8-only \
+    && make -j$(nproc) && make install \
+    && ldconfig \
+# build the dictionary
+    && cd "/usr/src/mecab/mecab-jumandic-${JUMANDIC_VERSION}" \
+    && ./configure --with-charset=utf8 \
+    && make -j$(nproc) && make install \
+# clean up
+    && rm -rf /usr/src/mecab \
+    && apt-mark auto '.*' > /dev/null \
+    && find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
+        | awk '/=>/ { print $(NF-1) }' \
+        | sort -u \
+        | xargs -r dpkg-query --search \
+        | cut -d: -f1 \
+        | sort -u \
+        | xargs -r apt-mark manual \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/* \
+    && mecab --version
+
+CMD /usr/local/bin/mecab


### PR DESCRIPTION
debian bullseye is now stable, and the code name of next release is bookworm.

https://www.debian.org/releases/bookworm/