### PR TITLE
bump Perl v5.40

### DIFF
--- a/.github/workflows/ipadic-alpine3.16.yml
+++ b/.github/workflows/ipadic-alpine3.16.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic alpine3.16
 

--- a/.github/workflows/ipadic-alpine3.17.yml
+++ b/.github/workflows/ipadic-alpine3.17.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic alpine3.17
 

--- a/.github/workflows/ipadic-alpine3.18.yml
+++ b/.github/workflows/ipadic-alpine3.18.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic alpine3.18
 

--- a/.github/workflows/ipadic-alpine3.19.yml
+++ b/.github/workflows/ipadic-alpine3.19.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic alpine3.19
 

--- a/.github/workflows/ipadic-bookworm.yml
+++ b/.github/workflows/ipadic-bookworm.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic bookworm
 

--- a/.github/workflows/ipadic-bullseye.yml
+++ b/.github/workflows/ipadic-bullseye.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic bullseye
 

--- a/.github/workflows/ipadic-buster.yml
+++ b/.github/workflows/ipadic-buster.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic buster
 

--- a/.github/workflows/ipadic-slim-bookworm.yml
+++ b/.github/workflows/ipadic-slim-bookworm.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic slim-bookworm
 

--- a/.github/workflows/ipadic-slim-bullseye.yml
+++ b/.github/workflows/ipadic-slim-bullseye.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic slim-bullseye
 

--- a/.github/workflows/ipadic-slim-buster.yml
+++ b/.github/workflows/ipadic-slim-buster.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl ipadic slim-buster
 

--- a/.github/workflows/jumandic-alpine3.16.yml
+++ b/.github/workflows/jumandic-alpine3.16.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic alpine3.16
 

--- a/.github/workflows/jumandic-alpine3.17.yml
+++ b/.github/workflows/jumandic-alpine3.17.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic alpine3.17
 

--- a/.github/workflows/jumandic-alpine3.18.yml
+++ b/.github/workflows/jumandic-alpine3.18.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic alpine3.18
 

--- a/.github/workflows/jumandic-alpine3.19.yml
+++ b/.github/workflows/jumandic-alpine3.19.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic alpine3.19
 

--- a/.github/workflows/jumandic-bookworm.yml
+++ b/.github/workflows/jumandic-bookworm.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic bookworm
 

--- a/.github/workflows/jumandic-bullseye.yml
+++ b/.github/workflows/jumandic-bullseye.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic bullseye
 

--- a/.github/workflows/jumandic-buster.yml
+++ b/.github/workflows/jumandic-buster.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic buster
 

--- a/.github/workflows/jumandic-slim-bookworm.yml
+++ b/.github/workflows/jumandic-slim-bookworm.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic slim-bookworm
 

--- a/.github/workflows/jumandic-slim-bullseye.yml
+++ b/.github/workflows/jumandic-slim-bullseye.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic slim-bullseye
 

--- a/.github/workflows/jumandic-slim-buster.yml
+++ b/.github/workflows/jumandic-slim-buster.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl jumandic slim-buster
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
 
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
 
       - run: ./scripts/release.pl

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,7 @@ jobs:
         uses: shogo82148/actions-github-app-token@v1
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - id: update
         name: update
         run: |

--- a/scripts/build.pl
+++ b/scripts/build.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use 5.38.0;
+use v5.40;
 use warnings;
 use utf8;
 use FindBin;

--- a/scripts/publish.pl
+++ b/scripts/publish.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use 5.38.0;
+use v5.40;
 use warnings;
 use utf8;
 use FindBin;

--- a/scripts/release.pl
+++ b/scripts/release.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use 5.38.0;
+use v5.40;
 use warnings;
 use utf8;
 use FindBin;

--- a/scripts/template.yml
+++ b/scripts/template.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: "5.38"
+          perl-version: "5.40"
       - run: |
           ./scripts/build.pl __DICTIONARY__ __DISTRIBUTION__
 

--- a/scripts/update_mecab.pl
+++ b/scripts/update_mecab.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use 5.38.0;
+use v5.40;
 use warnings;
 use utf8;
 use FindBin;

--- a/scripts/update_workflow.pl
+++ b/scripts/update_workflow.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use 5.38.0;
+use v5.40;
 use warnings;
 use utf8;
 use FindBin;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Perl version from `5.38` to `5.40` in various GitHub Actions workflows and scripts for improved compatibility and performance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->