### PR TITLE
remove buster and slim-buster variants from distributions.json

### DIFF
--- a/scripts/distributions.json
+++ b/scripts/distributions.json
@@ -3,8 +3,6 @@
     "slim-bookworm",
     "bullseye",
     "slim-bullseye",
-    "buster",
-    "slim-buster",
     "alpine3.21",
     "alpine3.20",
     "alpine3.19",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed "buster" and "slim-buster" distributions from the supported distributions list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->